### PR TITLE
fix geopy Error

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -19,9 +19,9 @@ from urllib import urlretrieve
 if os.environ.get('LAMBDA_TASK_ROOT') is None:
     print "just exit, we are not in a lambda function",
     import sys; sys.exit(0)
-    
-from geopy.geocoders import Nominatim
-geolocator = Nominatim()
+
+import geopy
+geolocator = geopy.geocoders.GoogleV3()
     
 # del all files in tmp directory - just in case
 import os


### PR DESCRIPTION
With `geolocator = Nominatim()`, the `geolocator.reverse(latlng)` will return 403 Error, as mentioned [here](https://github.com/geopy/geopy/issues/262)